### PR TITLE
Fix: Parameterize Host and Validation URL based on system environment…

### DIFF
--- a/index.py
+++ b/index.py
@@ -1,7 +1,7 @@
 from dash import Input, Output, State, html, dcc
 import dash_bootstrap_components as dbc
 import dash
-import dash_table
+from dash import dash_table
 import json
 import os
 import bfabric

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -40,13 +40,15 @@ def token_to_data(token: str) -> str:
         if not five_minutes_later <= datetime.datetime.strptime(expiry_time, "%Y-%m-%d %H:%M:%S"):
             return "EXPIRED"
         
+        environment_dict = {"Production":"https://fgcz-bfabric.uzh.ch/bfabric","Test":"https://fgcz-bfabric-test.uzh.ch/bfabric"}
+
         token_data = dict(
             environment = userinfo['environment'],
             user_data = userinfo['user'],
             token_expires = expiry_time,
             entity_id_data = userinfo['entityId'],
             entityClass_data = userinfo['entityClassName'],
-            webbase_data = validation_url.split('rest')[0],
+            webbase_data = environment_dict.get(userinfo['environment'], None),
             application_params_data = {},
             application_data = str(userinfo['applicationId']),
             userWsPassword = userinfo['userWsPassword']


### PR DESCRIPTION
To support test-only accounts, I refactored the code to allow validation_url and host to be configurable based on the environment. Additionally, I updated the import statement for dash_table from import dash_table to from dash import dash_table to remove the deprecation warning.